### PR TITLE
Bullet tracer implementation (#321)

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -173,6 +173,8 @@ namespace CVars
 	CVarWrapper bxt_viewmodel_ofs_right("bxt_viewmodel_ofs_right", "0");
 	CVarWrapper bxt_viewmodel_ofs_up("bxt_viewmodel_ofs_up", "0");
 	CVarWrapper bxt_viewmodel_bob_angled("bxt_viewmodel_bob_angled", "0");
+	CVarWrapper bxt_show_bullets("bxt_show_bullets", "0");
+	CVarWrapper bxt_show_bullets_enemy("bxt_show_bullets_enemy", "0");
 
 	const std::vector<CVarWrapper*> allCVars =
 	{
@@ -338,6 +340,8 @@ namespace CVars
 		&bxt_viewmodel_ofs_forward,
 		&bxt_viewmodel_ofs_right,
 		&bxt_viewmodel_ofs_up,
-		&bxt_viewmodel_bob_angled
+		&bxt_viewmodel_bob_angled,
+		&bxt_show_bullets,
+		&bxt_show_bullets_enemy,
 	};
 }

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -286,6 +286,8 @@ namespace CVars
 	extern CVarWrapper bxt_viewmodel_ofs_right;
 	extern CVarWrapper bxt_viewmodel_ofs_up;
 	extern CVarWrapper bxt_viewmodel_bob_angled;
+	extern CVarWrapper bxt_show_bullets;
+	extern CVarWrapper bxt_show_bullets_enemy;
 
 	extern const std::vector<CVarWrapper*> allCVars;
 }

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -301,6 +301,11 @@ extern "C" void __cdecl Draw_FillRGBA(int x, int y, int w, int h, int r, int g, 
 {
 	HwDLL::HOOKED_Draw_FillRGBA(x, y, w, h, r, g, b, a);
 }
+
+extern "C" void __cdecl PF_traceline_DLL(const Vector* v1, const Vector* v2, int fNoMonsters, edict_t* pentToSkip, TraceResult* ptr)
+{
+	HwDLL::HOOKED_PF_traceline_DLL(v1, v2, fNoMonsters, pentToSkip, ptr);
+}
 #endif
 
 void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* moduleBase, size_t moduleLength, bool needToIntercept)
@@ -415,6 +420,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			MemUtils::MarkAsExecutable(ORIG_SPR_Set);
 			MemUtils::MarkAsExecutable(ORIG_DrawCrosshair);
 			MemUtils::MarkAsExecutable(ORIG_Draw_FillRGBA);
+			MemUtils::MarkAsExecutable(ORIG_PF_traceline_DLL);
 		}
 
 		MemUtils::Intercept(moduleName,
@@ -467,7 +473,8 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			ORIG_R_SetFrustum, HOOKED_R_SetFrustum,
 			ORIG_SPR_Set, HOOKED_SPR_Set,
 			ORIG_DrawCrosshair, HOOKED_DrawCrosshair,
-			ORIG_Draw_FillRGBA, HOOKED_Draw_FillRGBA);
+			ORIG_Draw_FillRGBA, HOOKED_Draw_FillRGBA,
+			ORIG_PF_traceline_DLL, HOOKED_PF_traceline_DLL);
 	}
 }
 
@@ -525,7 +532,8 @@ void HwDLL::Unhook()
 			ORIG_R_SetFrustum,
 			ORIG_SPR_Set,
 			ORIG_DrawCrosshair,
-			ORIG_Draw_FillRGBA);
+			ORIG_Draw_FillRGBA,
+			ORIG_PF_traceline_DLL);
 	}
 
 	for (auto cvar : CVars::allCVars)
@@ -611,6 +619,7 @@ void HwDLL::Clear()
 	ORIG_SPR_Set = nullptr;
 	ORIG_DrawCrosshair = nullptr;
 	ORIG_Draw_FillRGBA = nullptr;
+	ORIG_PF_traceline_DLL = nullptr;
 
 	ClientDLL::GetInstance().pEngfuncs = nullptr;
 	ServerDLL::GetInstance().pEngfuncs = nullptr;
@@ -946,6 +955,12 @@ void HwDLL::FindStuff()
 		else
 			EngineDevWarning("[hw dll] Could not find Draw_FillRGBA.\n");
 
+		ORIG_PF_traceline_DLL = reinterpret_cast<_PF_traceline_DLL>(MemUtils::GetSymbolAddress(m_Handle, "PF_traceline_DLL"));
+		if (ORIG_PF_traceline_DLL)
+			EngineDevMsg("[hw dll] Found PF_traceline_DLL at %p.\n", ORIG_PF_traceline_DLL);
+		else
+			EngineDevWarning("[hw dll] Could not find PF_traceline_DLL.\n");
+
 		if (!cls || !sv || !svs || !svmove || !ppmove || !host_client || !sv_player || !sv_areanodes || !cmd_text || !cmd_alias || !host_frametime || !cvar_vars || !movevars || !ORIG_hudGetViewAngles || !ORIG_SV_AddLinksToPM || !ORIG_SV_SetMoveVars)
 			ORIG_Cbuf_Execute = nullptr;
 
@@ -1211,6 +1226,7 @@ void HwDLL::FindStuff()
 		DEF_FUTURE(SPR_Set)
 		DEF_FUTURE(DrawCrosshair)
 		DEF_FUTURE(Draw_FillRGBA)
+		DEF_FUTURE(PF_traceline_DLL)
 		#undef DEF_FUTURE
 
 		bool oldEngine = (m_Name.find(L"hl.exe") != std::wstring::npos);
@@ -1961,6 +1977,7 @@ void HwDLL::FindStuff()
 		GET_FUTURE(SPR_Set);
 		GET_FUTURE(DrawCrosshair);
 		GET_FUTURE(Draw_FillRGBA);
+		GET_FUTURE(PF_traceline_DLL);
 
 		if (oldEngine) {
 			GET_FUTURE(LoadAndDecryptHwDLL);
@@ -3503,6 +3520,28 @@ struct HwDLL::Cmd_BXT_TAS_Client_Load_Received_Script
 	}
 };
 
+struct HwDLL::Cmd_BXT_Show_Bullets_Clear
+{
+	NO_USAGE()
+
+	static void handler() {
+		auto& serverDLL = ServerDLL::GetInstance();
+
+		serverDLL.ClearBulletsTrace();
+	}
+};
+
+struct HwDLL::Cmd_BXT_Show_Bullets_Enemy_Clear
+{
+	NO_USAGE()
+
+	static void handler() {
+		auto& serverDLL = ServerDLL::GetInstance();
+
+		serverDLL.ClearBulletsEnemyTrace();
+	}
+};
+
 extern "C" DLLEXPORT void bxt_tas_load_script_from_string(const char *script)
 {
 	auto& hw = HwDLL::GetInstance();
@@ -3806,6 +3845,9 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_TAS_Become_Simulator_Client, Handler<>>("bxt_tas_become_simulator_client");
 	wrapper::Add<Cmd_BXT_TAS_Server_Send_Command, Handler<const char*>>("_bxt_tas_server_send_command");
 	wrapper::Add<Cmd_BXT_TAS_Client_Load_Received_Script, Handler<>>("_bxt_tas_client_load_received_script");
+
+	wrapper::Add<Cmd_BXT_Show_Bullets_Clear, Handler<>>("bxt_show_bullets_clear");
+	wrapper::Add<Cmd_BXT_Show_Bullets_Enemy_Clear, Handler<>>("bxt_show_bullets_enemy_clear");
 }
 
 void HwDLL::InsertCommands()
@@ -5858,4 +5900,11 @@ HOOK_DEF_8(HwDLL, void, __cdecl, Draw_FillRGBA, int, x, int, y, int, w, int, h, 
 		a = 255;
 
 	ORIG_Draw_FillRGBA(x, y, w, h, r, g, b, a);
+}
+
+HOOK_DEF_5(HwDLL, void, __cdecl, PF_traceline_DLL, const Vector*, v1, const Vector*, v2, int, fNoMonsters, edict_t*, pentToSkip, TraceResult*, ptr)
+{
+	ORIG_PF_traceline_DLL(v1, v2, fNoMonsters, pentToSkip, ptr);
+
+	ServerDLL::GetInstance().TraceLineWrap(v1, v2, fNoMonsters, pentToSkip, ptr);
 }

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -73,6 +73,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, SPR_Set, HSPRITE_HL hSprite, int r, int g, int b)
 	HOOK_DECL(void, __cdecl, DrawCrosshair, int x, int y)
 	HOOK_DECL(void, __cdecl, Draw_FillRGBA, int x, int y, int w, int h, int r, int g, int b, int a)
+	HOOK_DECL(void, __cdecl, PF_traceline_DLL, const Vector* v1, const Vector* v2, int fNoMonsters, edict_t* pentToSkip, TraceResult* ptr)
 
 	struct cmdbuf_t
 	{
@@ -442,6 +443,8 @@ protected:
 	struct Cmd_BXT_TAS_Become_Simulator_Client;
 	struct Cmd_BXT_TAS_Server_Send_Command;
 	struct Cmd_BXT_TAS_Client_Load_Received_Script;
+	struct Cmd_BXT_Show_Bullets_Clear;
+	struct Cmd_BXT_Show_Bullets_Enemy_Clear;
 
 	void RegisterCVarsAndCommandsIfNeeded();
 	void InsertCommands();

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -43,6 +43,10 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(void, __cdecl, CTriggerSave__SaveTouch_Linux, void* thisptr, void* pOther)
 	HOOK_DECL(void, __fastcall, CChangeLevel__UseChangeLevel, void* thisptr, int edx, void* pActivator, void* pCaller, int useType, float value)
 	HOOK_DECL(void, __fastcall, CChangeLevel__TouchChangeLevel, void* thisptr, int edx, void* pOther)
+	HOOK_DECL(void, __fastcall, CBaseEntity__FireBullets, void* thisptr, int param1, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker)
+	HOOK_DECL(void, __cdecl, CBaseEntity__FireBullets_Linux, void* thisptr, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker)
+	HOOK_DECL(void, __fastcall, CBaseEntity__FireBulletsPlayer, void* thisptr, int edx, float param1, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker, int shared_rand)
+	HOOK_DECL(Vector, __cdecl, CBaseEntity__FireBulletsPlayer_Linux, void* thisptr, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker, int shared_rand)
 
 public:
 	static ServerDLL& GetInstance()
@@ -78,6 +82,13 @@ public:
 
 	entvars_t *obboPushable = nullptr;
 
+	const std::deque<std::array<Vector, 2>>& GetBulletsEnemyTrace() const;
+	const std::deque<bool>& GetBulletsEnemyTraceHit() const;
+	const std::deque<std::array<Vector, 2>>& GetBulletsPlayerTrace() const;
+	const std::deque<bool>& GetBulletsPlayerTraceHit() const;
+	void ClearBulletsTrace();
+	void ClearBulletsEnemyTrace();
+	void TraceLineWrap(const Vector* vecStart, const Vector* vecEnd, int igmon, edict_t* pentIgnore, TraceResult* ptr);
 private:
 	ServerDLL() : IHookableDirFilter({ L"dlls" }) {};
 	ServerDLL(const ServerDLL&);
@@ -167,4 +178,11 @@ protected:
 	std::deque<TASLogger::Collision> secondFlyMoveTouchQueue;
 
 	std::unordered_map<int, bool> cantJumpNextTime;
+
+	unsigned long fireBulletsPlayer_count = 0;
+	unsigned long fireBullets_count = 0;
+	std::deque<std::array<Vector, 2>> traceLineFireBulletsPlayer;
+	std::deque<bool> traceLineFireBulletsPlayerHit;
+	std::deque<std::array<Vector, 2>> traceLineFireBullets;
+	std::deque<bool> traceLineFireBulletsHit;
 };

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -539,6 +539,13 @@ namespace patterns
 			"HL-WON-1712",
 			"83 EC 08 53 56 57 68 E1 0D 00 00 FF 15"
 		);
+
+		PATTERNS(PF_traceline_DLL,
+			"HL-SteamPipe",
+			"55 8B EC 8B 45 14 85 C0 75 05 A1 ?? ?? ?? ?? 8B 4D 0C 8B 55 08 56 50 8B 45 10 50 51 52 E8 ?? ?? ?? ?? D9 05",
+			"HL-4554",
+			"8B 44 24 10 85 C0 75 05 A1 ?? ?? ?? ?? 8B 4C 24 08 8B 54 24 04 56 50 8B 44 24 14 50 51 52 E8 ?? ?? ?? ?? D9 05"
+		);
 	}
 
 	namespace server
@@ -750,6 +757,20 @@ namespace patterns
 			"3B FE 74 ?? 8B 55",
 			"AoMDC",
 			"8B 45 ?? 3B 45 ?? 74 ?? 8B 4D ?? 51 8B 55 ?? 52 FF 15"
+		);
+
+		PATTERNS(CBaseEntity__FireBullets,
+			"HL-SteamPipe-6153",
+			"81 EC FC 00 00 00",
+			"Echoes",
+			"55 8B EC 81 EC 80 01 00 00"
+		);
+
+		PATTERNS(CBaseEntity__FireBulletsPlayer,
+			"HL-SteamPipe-6153",
+			"81 EC B0 00 00 00 A1",
+			"Echoes",
+			"55 8B EC 81 EC 10 01 00 00 89 8D ?? ?? ?? ?? 8D 4D"
 		);
 	}
 

--- a/BunnymodXT/stdafx.hpp
+++ b/BunnymodXT/stdafx.hpp
@@ -185,8 +185,26 @@ const unsigned FCAP_MASTER = 0x00000080;
 	} \
 	ret class::HOOKED_##name##_Func(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8)
 
+#define HOOK_DEF_10(class, ret, call, name, t1, n1, t2, n2, t3, n3, t4, n4, t5, n5, t6, n6, t7, n7, t8, n8, t9, n9, t10, n10) \
+	ret call class::HOOKED_##name(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10) { \
+		return class::GetInstance().HOOKED_##name##_Func(n1, n2, n3, n4, n5, n6, n7, n8, n9, n10); \
+	} \
+	ret class::HOOKED_##name##_Func(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10)
+
 #define HOOK_DEF_11(class, ret, call, name, t1, n1, t2, n2, t3, n3, t4, n4, t5, n5, t6, n6, t7, n7, t8, n8, t9, n9, t10, n10, t11, n11) \
 	ret call class::HOOKED_##name(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10, t11 n11) { \
 		return class::GetInstance().HOOKED_##name##_Func(n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11); \
 	} \
 	ret class::HOOKED_##name##_Func(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10, t11 n11)
+
+#define HOOK_DEF_12(class, ret, call, name, t1, n1, t2, n2, t3, n3, t4, n4, t5, n5, t6, n6, t7, n7, t8, n8, t9, n9, t10, n10, t11, n11, t12, n12) \
+	ret call class::HOOKED_##name(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10, t11 n11, t12 n12) { \
+		return class::GetInstance().HOOKED_##name##_Func(n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12); \
+	} \
+	ret class::HOOKED_##name##_Func(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10, t11 n11, t12 n12)
+
+#define HOOK_DEF_13(class, ret, call, name, t1, n1, t2, n2, t3, n3, t4, n4, t5, n5, t6, n6, t7, n7, t8, n8, t9, n9, t10, n10, t11, n11, t12, n12, t13, n13) \
+	ret call class::HOOKED_##name(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10, t11 n11, t12 n12, t13 n13) { \
+		return class::GetInstance().HOOKED_##name##_Func(n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13); \
+	} \
+	ret class::HOOKED_##name##_Func(t1 n1, t2 n2, t3 n3, t4 n4, t5 n5, t6 n6, t7 n7, t8 n8, t9 n9, t10 n10, t11 n11, t12 n12, t13 n13)

--- a/BunnymodXT/triangle_drawing.cpp
+++ b/BunnymodXT/triangle_drawing.cpp
@@ -301,6 +301,65 @@ namespace TriangleDrawing
 		}
 	}
 
+	static void DrawBullets(triangleapi_s* pTriAPI, const std::deque<std::array<Vector, 2>>& points_vec, const std::deque<bool>& hit_vec, byte r, byte g, byte b)
+	{
+		byte rEnd = 255 - r, gEnd = 255 - g, bEnd = 255 - b;
+
+		float r_float = r / 255.0f, g_float = g / 255.0f, b_float = b / 255.0f;
+		float rEnd_float = rEnd / 255.0f, gEnd_float = gEnd / 255.0f, bEnd_float = bEnd / 255.0f;
+
+		for (size_t i = 0; i < points_vec.size(); i++)
+		{
+			const auto points = points_vec.at(i);
+			const auto hit = hit_vec.at(i);
+			
+			float hitAlpha = 0.3f;
+			if (hit)
+				hitAlpha = 1.0f;
+
+			float lastHalfDist = 20.0f;
+			float totalLenMin = 60.0f;
+			auto diff = points[1] - points[0];
+			auto diffLen = diff.Length();
+			Vector half;
+			if (diffLen < totalLenMin) {
+				auto diffFirstHalf = diff * 0.7f;
+				half = points[0] + diffFirstHalf;
+			}
+			else {
+				auto diffFirstHalf = diff - diff.Normalize() * lastHalfDist;
+				half = points[0] + diffFirstHalf;
+			}
+			
+			pTriAPI->Color4f(r_float, g_float, b_float, hitAlpha);
+			TriangleUtils::DrawLine(pTriAPI, points[0], half);
+			pTriAPI->Color4f(rEnd_float, gEnd_float, bEnd_float, hitAlpha);
+			TriangleUtils::DrawLine(pTriAPI, half, points[1]);
+		}
+	}
+
+	static void DrawBulletsEnemyTrace(triangleapi_s* pTriAPI)
+	{
+		if (!CVars::bxt_show_bullets_enemy.GetBool())
+			return;
+
+		const auto points_vec = ServerDLL::GetInstance().GetBulletsEnemyTrace();
+		const auto hit_vec = ServerDLL::GetInstance().GetBulletsEnemyTraceHit();
+
+		DrawBullets(pTriAPI, points_vec, hit_vec, 255, 0, 144);
+	}
+
+	static void DrawBulletsPlayerTrace(triangleapi_s* pTriAPI)
+	{
+		if (!CVars::bxt_show_bullets.GetBool())
+			return;
+
+		const auto points_vec = ServerDLL::GetInstance().GetBulletsPlayerTrace();
+		const auto hit_vec = ServerDLL::GetInstance().GetBulletsPlayerTraceHit();
+
+		DrawBullets(pTriAPI, points_vec, hit_vec, 0, 200, 255);
+	}
+
 	static Vector perpendicular(const Vector &prev, const Vector &next) {
 		Vector perpendicular;
 
@@ -2163,6 +2222,8 @@ namespace TriangleDrawing
 		DrawTriggers(pTriAPI);
 		DrawCustomTriggers(pTriAPI);
 		DrawAbsMinMax(pTriAPI);
+		DrawBulletsEnemyTrace(pTriAPI);
+		DrawBulletsPlayerTrace(pTriAPI);
 
 		DrawTASEditor(pTriAPI);
 		ResetTASEditorCommands();


### PR DESCRIPTION
* Basic bullet tracing works

* Added CVars for bullet tracing

* Filter out actual FireBullets call

* bxt_show_bullets_color commands

* Added echoes pattern for FireBullets, UTIL_TraceLine

* Bullets tracer linux support

* fix bullet tracing for linux

* Fixed windows crashing on FireBullets call

* Fixed linux FireBulletsPlayer call args

* Fixed Linux implementation

* Minor style modification to be consistent with the rest of the HOOK_DEFs

* yalter happy

* Replaced UTIL_TraceLine with PF_traceline_DLL

* Proper line tracing end check

* Colour invert on hit place

* else if instead of two ifs

* Transparent bullet trace on miss

* Fixed miss alpha not applying to each line

* Better check on if bullet was actually fired

* Include hitting func_wall as a missed shot

* Fixed FireBullets cShots using wrong param

* Hitting func_wall_toggle counts as a missed bullet

* Added entities to count as missed bullet

* Prevent bullet line hit colour being too short

* Bullet hit check by checking solid property

* Clear bullet trace on map / save load

* removed bullet_limit, color, miss_alpha cvars

* return on failed bullet fire check

* return references instead

* clear bullets on load fix

* fixed signature

* Fixed TraceLine condition check

* Only level change clears bullets

* Removed unused UTIL_TraceLine hook decl

* Fixed minor style issue

* Update BunnymodXT/modules/ServerDLL.cpp

Co-authored-by: Jakub Mach <jakub.m4ch@gmail.com>
Co-authored-by: SmileyAG <redstyle45@gmail.com>
Co-authored-by: Ivan Molodetskikh <yalterz@gmail.com>